### PR TITLE
Fix the "persistence" bug

### DIFF
--- a/src/SignInScreen/SignInScreen.js
+++ b/src/SignInScreen/SignInScreen.js
@@ -26,11 +26,13 @@ export default class SignInScreen extends React.Component {
     };
   }
 
-
   // Listen to the Firebase Auth state and set the local state.
   componentDidMount() {
     this.unregisterAuthObserver = firebase.auth().onAuthStateChanged(
-        (user) => this.setState({isSignedIn: !!user})
+        (user) => {
+          this.setState({isSignedIn: !!user});
+          this.props.setSignInState(!!user);
+        }
     );
   }
 
@@ -46,12 +48,5 @@ export default class SignInScreen extends React.Component {
         <StyledFirebaseAuth uiConfig={this.uiConfig} firebaseAuth={firebase.auth()}/>
       </div>
     );
-    // return (
-    //   <div>
-    //     <h1>My App</h1>
-    //     <p>Welcome {firebase.auth().currentUser.displayName}! You are now signed-in!</p>
-    //     <a onClick={() => firebase.auth().signOut()}>Sign-out</a>
-    //   </div>
-    // );
   }
 }


### PR DESCRIPTION
**This fixes the issue with persistence**

![thank god](https://media0.giphy.com/media/QWjFSsvUPCUncq6ItU/giphy.gif)

`signInSuccessWithAuthResult` only gets called when user actually signs in, NOT when the user is already signed in, hence no persistence.
We should use the `onAuthStateChanged` callback instead.

